### PR TITLE
Update js install instructions to use yarn for installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ ipfs:
 Direct uploads can be used by installing `activestorage-ipfs-js` run:
 
 ```
-npm install activestorage-ipfs-js
+yarn install activestorage-ipfs-js
 ```
 
 After installing the js package replace this line in `app/javascript/packs/application.js`


### PR DESCRIPTION
Rails 6 defaults to yarn for installing js packages, if you use `npm install` then you get the following error when trying to start rails:
```
error Lockfile does not contain pattern: "activestorage-ipfs-js@^1.0.0"                                                  
error Found 1 errors.                                                                                                    


========================================
  Your Yarn packages are out of date!
  Please run `yarn install --check-files` to update.
========================================


To disable this check, please change `check_yarn_integrity`
to `false` in your webpacker config file (config/webpacker.yml).


yarn check v1.6.0
info Visit https://yarnpkg.com/en/docs/cli/check for documentation about this command.


Exiting
```